### PR TITLE
新增 Remote/Local 翻譯檔讀取模式、自動尋找 Notion 預設路徑

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +579,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -999,6 +1031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1060,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -1080,11 +1118,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -1391,7 +1449,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
@@ -1633,6 +1691,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "asar",
+ "directories",
  "reqwest",
  "tokio",
  "toml_edit",

--- a/env.toml
+++ b/env.toml
@@ -1,3 +1,18 @@
 version = "2.4.20"
-folder = "/mnt/c/Users/Gemini/AppData/Local/Programs/Notion"
-remote_url="https://greasyfork.org/scripts/430116-notion-zh-cn-notion%E7%9A%84%E6%B1%89%E5%8C%96%E8%84%9A%E6%9C%AC/code/Notion-zh_CN%20notion%E7%9A%84%E6%B1%89%E5%8C%96%E8%84%9A%E6%9C%AC.user.js"
+# Default `%appdata%/../Local/Programs/Notion`
+folder = "~"
+
+# Use local
+# - zh_CN -
+# local_url="Notion-zh_CN.js"
+
+# - zh_TW -
+# local_url="Notion-zh_TW.js"
+
+
+# Use remote
+# - zh_CN -
+remote_url="https://raw.githubusercontent.com/Reamd7/notion-zh_CN/main/notion-zh_CN.js"
+
+# - zh_TW -
+# remote_url="https://raw.githubusercontent.com/Reamd7/notion-zh_CN/main/notion-zh_TW.js"

--- a/update_asar/Cargo.toml
+++ b/update_asar/Cargo.toml
@@ -11,3 +11,4 @@ asar = "0.2.0"
 reqwest = { version = "0.11.20", features = ["json"] }
 tokio = { version = "1.32.0", features = ["full"] }
 toml_edit = "0.20.0"
+directories = "5.0.1"


### PR DESCRIPTION
- 新增 directories crate 獲取 `appdata/local` 路徑
- 可選 本地/遠端 獲取翻譯檔
- `env.toml` 完善